### PR TITLE
Recover Some errors 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,12 @@
-use crate::image_utils::ImageMode;
+use crate::image_utils::PaperMode;
 use argh::FromArgs;
 use std::path::PathBuf;
 
-fn modes_str_fn(_value: &str) -> Result<ImageMode, String> {
+fn modes_str_fn(_value: &str) -> Result<PaperMode, String> {
     match _value {
-        "strim" => Ok(ImageMode::Strim),
-        "fill" => Ok(ImageMode::Fill),
-        "stretch" => Ok(ImageMode::Stretch),
+        "strim" => Ok(PaperMode::Strim),
+        "fill" => Ok(PaperMode::Fill),
+        "stretch" => Ok(PaperMode::Stretch),
         _ => Err(format!("no mode name \"{}\"", _value)),
     }
 }
@@ -19,6 +19,6 @@ pub struct Cli {
     pub path: PathBuf,
 
     /// default mode: strim, available modes: strim, stretch, fill
-    #[argh(option, default = "ImageMode::default()", from_str_fn(modes_str_fn))]
-    pub mode: ImageMode,
+    #[argh(option, default = "PaperMode::default()", from_str_fn(modes_str_fn))]
+    pub mode: PaperMode,
 }

--- a/src/image_utils/mod.rs
+++ b/src/image_utils/mod.rs
@@ -4,7 +4,7 @@ use image::{DynamicImage, RgbImage};
 use std::path::Path;
 
 #[derive(Debug, Default)]
-pub enum ImageMode {
+pub enum PaperMode {
     /// This mode stretches and blur the image to fit the entire screen,
     /// and then add a scaled image on top of it
     #[default]
@@ -17,7 +17,7 @@ pub enum ImageMode {
     Fill,
 }
 
-impl ImageMode {
+impl PaperMode {
     /// apply the mode to the given Image, it will return another modified image has the same dimentions
     pub fn apply(&self, image: DynamicImage, dim: (u32, u32)) -> RgbImage {
         match self {

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,7 +1,7 @@
 pub mod desktop_env;
 pub mod utils;
 
-use crate::{ImageMode, Platform};
+use crate::{PaperMode, Platform};
 use anyhow::Result;
 use desktop_env::DesktopEnv;
 use std::path::PathBuf;
@@ -28,13 +28,13 @@ impl LinuxEnv {
     }
 
     /// Sets the background using shell commands.
-    pub fn set_bg_shell(&self, bg_path: PathBuf, mode: ImageMode) -> Result<()> {
+    pub fn set_bg_shell(&self, bg_path: PathBuf, mode: PaperMode) -> Result<()> {
         let copied_path = copy_bg_with_mode(bg_path, mode)?;
         run_shell(&self.config_path, &copied_path)
     }
 
     /// Sets the background using XCB.
-    pub fn set_bg_xcb(bg_path: PathBuf, mode: ImageMode) -> Result<()> {
+    pub fn set_bg_xcb(bg_path: PathBuf, mode: PaperMode) -> Result<()> {
         let image = image::open(bg_path)?;
         let dim = get_display_info()?;
         let resized_image = mode.apply(image, dim);
@@ -47,7 +47,7 @@ impl Platform for LinuxEnv {
     /// This function check first if the shell script for the current desktop exists
     /// and execut it, It use XCB Library instead if the current desktop not supported
     /// and the `setter.sh` file not exists in the config dir
-    fn set_bg(bg_path: PathBuf, mode: ImageMode) -> Result<()> {
+    fn set_bg(bg_path: PathBuf, mode: PaperMode) -> Result<()> {
         let env = Self::new()?;
         match (env.config_path.exists(), &env.current_desktop) {
             (false, DesktopEnv::Other) => Self::set_bg_xcb(bg_path, mode),

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -19,7 +19,7 @@ pub struct LinuxEnv {
 impl LinuxEnv {
     /// New instance of LinuxEnv with default values
     pub fn new() -> Result<Self> {
-        let current_desktop = DesktopEnv::get_current()?;
+        let current_desktop = DesktopEnv::get_current();
         let config_path: PathBuf = desktop_config_path(&current_desktop)?;
         Ok(Self {
             current_desktop,

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -1,7 +1,7 @@
 pub mod desktop_env;
 pub mod utils;
 
-use crate::{PaperMode, Platform};
+use crate::{PaperMode, PaperSetter};
 use anyhow::Result;
 use desktop_env::DesktopEnv;
 use std::path::PathBuf;
@@ -42,7 +42,7 @@ impl LinuxEnv {
     }
 }
 
-impl Platform for LinuxEnv {
+impl PaperSetter for LinuxEnv {
     /// Sets the background on a Linux system.
     /// This function check first if the shell script for the current desktop exists
     /// and execut it, It use XCB Library instead if the current desktop not supported

--- a/src/linux/utils.rs
+++ b/src/linux/utils.rs
@@ -1,4 +1,4 @@
-use crate::image_utils::ImageMode;
+use crate::image_utils::PaperMode;
 use crate::linux::desktop_env::DesktopEnv;
 use anyhow::Result;
 use std::path::{Path, PathBuf};
@@ -33,7 +33,7 @@ pub fn create_config_dir() -> Result<()> {
     Ok(())
 }
 
-pub fn copy_bg_with_mode(bg_path: PathBuf, mode: ImageMode) -> Result<PathBuf> {
+pub fn copy_bg_with_mode(bg_path: PathBuf, mode: PaperMode) -> Result<PathBuf> {
     let config_bg = config_dir()?.join("current");
     let dim = get_display_info()?;
     mode.apply_with_save(&bg_path, &config_bg, dim)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ pub mod image_utils;
 #[cfg(target_os = "linux")]
 mod linux;
 
-use crate::image_utils::ImageMode;
+use crate::image_utils::PaperMode;
 use anyhow::anyhow;
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
@@ -23,15 +23,15 @@ fn is_image<P: AsRef<Path>>(path: P) -> anyhow::Result<bool> {
 }
 
 /// A trait for setting wallpapers on different platforms
-pub trait Platform {
+pub trait PaperSetter {
     /// Set a specified wallpaper to the specified mode
-    fn set_bg(path: PathBuf, mode: ImageMode) -> anyhow::Result<()>;
+    fn set_bg(path: PathBuf, mode: PaperMode) -> anyhow::Result<()>;
 
     /// sets a random wallpaper from a list of paths to the specified mode.
     /// filters the list to contain only valid image files, and calls the set_bg method.
     fn set_random_bg(
         paths_list: impl IteratorRandom<Item = PathBuf>,
-        mode: ImageMode,
+        mode: PaperMode,
     ) -> anyhow::Result<()> {
         let mut rng = thread_rng();
         let random_path = paths_list


### PR DESCRIPTION
 - get rid of `Result` in `DesktopEnv::get_current` function and just return the default value if no environment variables is found 
 - return `false` instead of error in `is_image` function
 - replace some names